### PR TITLE
fix: install libzip-dev system dependency for lua-zip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Set up LuaRocks
         uses: leafo/gh-actions-luarocks@v4
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libzip-dev
+
       - name: Install dependencies from rockspec
         run: |
           luarocks make capsium-dev-1.rockspec --only-deps


### PR DESCRIPTION
## Problem

The GitHub Actions tests were failing because the `lua-zip` LuaRocks dependency requires system-level `libzip` development headers to compile.

Error from the failed test run:
```
Error: Failed installing dependency: https://luarocks.org/lua-zip-0.2-0.src.rock - Could not find header file for ZIP
  No file zip.h in /usr/local/include
  No file zip.h in /usr/include
  No file zip.h in /include
You may have to install ZIP in your system and/or pass ZIP_DIR or ZIP_INCDIR to the luarocks command.
```

## Solution

Added a new step in the workflow to install the `libzip-dev` package before installing Lua dependencies:

```yaml
- name: Install system dependencies
  run: |
    sudo apt-get update
    sudo apt-get install -y libzip-dev
```

This ensures the required headers are available when LuaRocks tries to compile `lua-zip`.

## Testing

The workflow will run automatically when this PR is merged, testing across all Lua versions (5.1, 5.2, 5.3, 5.4, and LuaJIT).

Fixes capsiums/capsium-lua#18560268949