### PR TITLE
fix: use explicit LuaJIT version instead of shorthand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        lua-version: ['5.1', '5.2', '5.3', '5.4', 'luajit']
+        lua-version: ['5.1', '5.2', '5.3', '5.4', 'luajit-2.1.0-beta3']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The GitHub Actions tests were failing for LuaJIT with a 404 error:
```
Error: Failed to install Lua: Error: Unexpected HTTP response: 404
```

This was caused by using the shorthand `luajit` version alias, which doesn't resolve properly in the gh-actions-lua action.

## Solution

According to the [gh-actions-lua documentation](https://github.com/leafo/gh-actions-lua), LuaJIT versions should be specified explicitly with the full version string like `luajit-2.1.0-beta3`.

Changed the matrix from:
```yaml
matrix:
  lua-version: ['5.1', '5.2', '5.3', '5.4', 'luajit']
```

To:
```yaml
matrix:
  lua-version: ['5.1', '5.2', '5.3', '5.4', 'luajit-2.1.0-beta3']
```

This ensures the action can properly download and install the correct LuaJIT version.

## Testing

The workflow will run automatically when this PR is merged, testing across all Lua versions including the explicit LuaJIT version.